### PR TITLE
bin/markdown2confluence: Fix stdin/stdout support to match the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,21 @@ npm i --save @shogobg/markdown2confluence
 
 ## Command-Line Use
 
-Use it to convert a markdown file.
-
-    markdown2confluence README.md
-
-Or pipe in a file.
-
-    cat README.md | markdown2confluence
+Read in a Markdown file and write Confluence format to another file:
 
 ```sh
 markdown2confluence <path/to/markdown.md> <path/to/output.txt>
 ```
+
+Or output to standard output:
+
+    markdown2confluence README.md
+
+Or pipe in a file and output to standard output:
+
+    cat README.md | markdown2confluence
+
+(Piping into markdown2confluence only works on platforms that support /dev/stdin, for example not Windows.)
 
 ## As library dependency
 

--- a/bin/markdown2confluence.js
+++ b/bin/markdown2confluence.js
@@ -6,7 +6,10 @@ var assert = require('assert');
 
 var filename = process.argv[2];
 const outputFileName = process.argv[3];
-assert(filename, 'should have filename');
+
+if (!filename) {
+    filename = "/dev/stdin";
+}
 
 fs.readFile(path.resolve(process.cwd(), filename), (err, buffer) => {
   assert(!err, 'read file ' + filename + ' error!');
@@ -24,6 +27,8 @@ fs.readFile(path.resolve(process.cwd(), filename), (err, buffer) => {
       path.resolve(process.cwd(), outputFileName),
       confluenceMarkup,
     );
+  } else {
+    console.log(confluenceMarkup);
   }
 
   return confluenceMarkup;


### PR DESCRIPTION
Thanks for keeping this project maintained, it's much appreciated. :)

I noticed the README documents that the command line tool can read from stdin and write to stdout, but these were no longer supported. This commit brings them back.
